### PR TITLE
Telephony: change input type to phone for my phone no.

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -35,6 +35,7 @@
     <!-- My Phone Number -->
     <string name="phone_number_label">My phone number</string>
     <string name="phone_number_summary">Set the phone number for this device</string>
+    <string name="set_my_number_failed">Failed to set phone number</string>
     <string name="msisdn_alpha_tag" translatable="false">Voice Line 1</string>
 
     <!-- Toasts for various transient network events -->

--- a/res/xml/gsm_umts_additional_options.xml
+++ b/res/xml/gsm_umts_additional_options.xml
@@ -26,6 +26,7 @@
         android:key="button_pn_key"
         android:title="@string/phone_number_label"
         android:summary="@string/phone_number_summary"
+        android:inputType="phone"
         android:dialogTitle="@string/phone_number_label"
         android:dialogMessage="@string/phone_number_summary"
         android:negativeButtonText="@string/cancel"

--- a/src/com/android/phone/MSISDNEditPreference.java
+++ b/src/com/android/phone/MSISDNEditPreference.java
@@ -26,6 +26,7 @@ import android.preference.EditTextPreference;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.android.internal.telephony.Phone;
 import com.android.internal.telephony.PhoneFactory;
@@ -64,8 +65,13 @@ public class MSISDNEditPreference extends EditTextPreference {
                 alphaTag = getContext().getString(R.string.msisdn_alpha_tag);
             }
 
-            mPhone.setLine1Number(alphaTag, getText(),
-                    mHandler.obtainMessage(MyHandler.MESSAGE_SET_MSISDN));
+            if (!mPhone.setLine1Number(alphaTag, getText(),
+                    mHandler.obtainMessage(MyHandler.MESSAGE_SET_MSISDN))) {
+                // unknown failure returned from setLine1Number
+                Toast.makeText(getContext(), getContext().getString(R.string.set_my_number_failed),
+                        Toast.LENGTH_LONG).show();
+                return;
+            }
             if (mTcpListener != null) {
                 mTcpListener.onStarted(this, false);
             }
@@ -136,6 +142,8 @@ public class MSISDNEditPreference extends EditTextPreference {
                     Log.d(LOG_TAG, "handleSetMSISDNResponse: ar.exception=" + ar.exception);
                 }
                 // setEnabled(false);
+                Toast.makeText(getContext(), getContext().getString(R.string.set_my_number_failed),
+                        Toast.LENGTH_LONG).show();
             }
             if (DBG) {
                 Log.d(LOG_TAG, "handleSetMSISDNResponse: re get");


### PR DESCRIPTION
The my phone number (msisdn) is only accept phone digits.
Change the input type to prevent launch full keyboard
for input it.

Also add a prompt if set my phone number failed.
(Possibly due to length limit in SIM, however there is no
standard on maximum length, so we cannot limit it on input,
must set and check)

FEIJ-1219

Change-Id: I06ed2a4b325ba9475476bdbaeefd22154632863c
