### PR TITLE
Telephony: Fix voicemail preference issue

### DIFF
--- a/src/com/android/phone/settings/VoicemailSettingsActivity.java
+++ b/src/com/android/phone/settings/VoicemailSettingsActivity.java
@@ -235,12 +235,20 @@ public class VoicemailSettingsActivity extends PreferenceActivity
         super.onResume();
         mForeground = true;
 
-        PreferenceScreen preferenceScreen = getPreferenceScreen();
-        if (preferenceScreen != null) {
-            preferenceScreen.removeAll();
+        /* no need to redo layout */
+        if ((findPreference(BUTTON_VOICEMAIL_KEY) != null) &&
+            (mSubMenuVoicemailSettings != null)) {
+            return;
         }
 
-        addPreferencesFromResource(R.xml.voicemail_settings);
+        /* This happends when orientation change or first created */
+        if (mSubMenuVoicemailSettings == null) {
+            PreferenceScreen preferenceScreen = getPreferenceScreen();
+            if (preferenceScreen != null) {
+                preferenceScreen.removeAll();
+            }
+            addPreferencesFromResource(R.xml.voicemail_settings);
+        }
 
         PreferenceScreen prefSet = getPreferenceScreen();
         mSubMenuVoicemailSettings = (EditPhoneNumberPreference) findPreference(BUTTON_VOICEMAIL_KEY);
@@ -541,7 +549,11 @@ public class VoicemailSettingsActivity extends PreferenceActivity
                     if (DBG) log("onActivityResult: bad contact data, no results found.");
                     return;
                 }
-                mSubMenuVoicemailSettings.onPickActivityResult(cursor.getString(0));
+                EditPhoneNumberPreference voiceSettings = (EditPhoneNumberPreference)
+                    findPreference(BUTTON_VOICEMAIL_KEY);
+                if (voiceSettings != null) {
+                    voiceSettings.onPickActivityResult(cursor.getString(0));
+                }
                 return;
             } finally {
                 if (cursor != null) {
@@ -597,12 +609,10 @@ public class VoicemailSettingsActivity extends PreferenceActivity
             return;
         }
 
-        if (preference == mSubMenuVoicemailSettings) {
-            VoicemailProviderSettings newSettings = new VoicemailProviderSettings(
-                    mSubMenuVoicemailSettings.getPhoneNumber(),
-                    VoicemailProviderSettings.NO_FORWARDING);
-            saveVoiceMailAndForwardingNumber(mVoicemailProviders.getKey(), newSettings);
-        }
+        VoicemailProviderSettings newSettings = new VoicemailProviderSettings(
+                preference.getPhoneNumber(),
+                VoicemailProviderSettings.NO_FORWARDING);
+        saveVoiceMailAndForwardingNumber(mVoicemailProviders.getKey(), newSettings);
     }
 
     /**


### PR DESCRIPTION
The preferences are all removed and re-created during onResume,
this causes multiple problem, as pick contact list will fire new activity
and when it return back, VoicemailSettingsActivity onResume is called,
making mSubMenuVoicemailSettings pointer to a new object instead of
the one being currently displayed. Therefore saveVoiceMailAndForwardingNumber
is not called. Same situation happens when Phone is temperory put into background
and then back again.

Also during screen orientation change in contact picker, VoicemailSettingsActivity
will be re-created when return, causing mSubMenuVoicemailSettings equal to null and
crash the Phone application

Fix it by avoid un-necessary layout re-creation

CYNGNOS-3184, FEIJ-1504, FEIJ-1505

Change-Id: Iee35b165e5f0aba1aba11c197a513278412b8207
